### PR TITLE
Cleanup config

### DIFF
--- a/etc/skel/.config/picom/picom.conf
+++ b/etc/skel/.config/picom/picom.conf
@@ -56,7 +56,7 @@ popup_menu = { opacity = 0.8; }
 dropdown_menu = { opacity = 0.8; }
 inactive-opacity-override = false;
 active-opacity = 1.0;
- inactive-dim = 0.2
+inactive-dim = 0.2;
 focus-exclude = [
   "class_g = 'Cairo-clock'",
   "class_g = 'Bar'",                    # lemonbar
@@ -106,7 +106,6 @@ blur-background-exclude = [
   "_GTK_FRAME_EXTENTS@:c"
 ];
 # daemon = false
-experimental-backends = true;
 backend = "glx";
 vsync = true
 # dbus = false
@@ -114,7 +113,6 @@ mark-wmwin-focused = true;
 mark-ovredir-focused = true;
 detect-rounded-corners = true;
 detect-client-opacity = true;
-refresh-rate = 0
 # sw-opti =
 # use-ewmh-active-win = false
 unredir-if-possible = true
@@ -124,7 +122,7 @@ detect-transient = true
 detect-client-leader = true
 # resize-damage = 1
 # invert-color-include = []
-# glx-no-stencil = false
+glx-no-stencil = true
 # glx-no-rebind-pixmap = false
 # no-use-damage = false
 use-damage = false


### PR DESCRIPTION
- Since v10 `--experimental-backends` is now enabled by default (https://github.com/yshui/picom/commit/7e607bfe81378ac3f07f6e448fd9803f48fddc01)
- Since v10 `--refresh-rate` has been removed, now the refresh rate is determined automatically (https://github.com/yshui/picom/commit/bcbc410c927bf1f7b72b3536911b3c9621ba92fc)
- Enable `--glx-no-stencil`. According to the description man increases performance by 15%, I also noticed a strong increase in smoothness after enabling it, but it can break` --blur-background`, which however is turned off by default in your config, so I do not consider it a big problem.

@vnepogodin 